### PR TITLE
Update vulnerable dependencies to patched versions

### DIFF
--- a/JAVA/JavaSpring/CompanyFounders/bin/pom.xml
+++ b/JAVA/JavaSpring/CompanyFounders/bin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.CompanyFounders</groupId>

--- a/JAVA/JavaSpring/CompanyFounders/pom.xml
+++ b/JAVA/JavaSpring/CompanyFounders/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.CompanyFounders</groupId>

--- a/JAVA/JavaSpring/Counter/pom.xml
+++ b/JAVA/JavaSpring/Counter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.Counter</groupId>

--- a/JAVA/JavaSpring/Course/pom.xml
+++ b/JAVA/JavaSpring/Course/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.2.RELEASE</version>
+        <version>2.7.18</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <properties>

--- a/JAVA/JavaSpring/DojoOverflow/pom.xml
+++ b/JAVA/JavaSpring/DojoOverflow/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.DojoOverflow</groupId>

--- a/JAVA/JavaSpring/DojoSurvey/pom.xml
+++ b/JAVA/JavaSpring/DojoSurvey/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.DojoSurvey</groupId>

--- a/JAVA/JavaSpring/EventBeltReviewer/pom.xml
+++ b/JAVA/JavaSpring/EventBeltReviewer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.EventBeltReviewer</groupId>

--- a/JAVA/JavaSpring/FamiliarWithRouting/pom.xml
+++ b/JAVA/JavaSpring/FamiliarWithRouting/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.stringAssignment</groupId>

--- a/JAVA/JavaSpring/GreatIdeas/pom.xml
+++ b/JAVA/JavaSpring/GreatIdeas/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.GreatIdeas</groupId>

--- a/JAVA/JavaSpring/HelloHuman/pom.xml
+++ b/JAVA/JavaSpring/HelloHuman/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.stringAssignment</groupId>

--- a/JAVA/JavaSpring/MVC/pom.xml
+++ b/JAVA/JavaSpring/MVC/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.MVC</groupId>

--- a/JAVA/JavaSpring/Movies/pom.xml
+++ b/JAVA/JavaSpring/Movies/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.mvcdemo</groupId>

--- a/JAVA/JavaSpring/NinjaGold/pom.xml
+++ b/JAVA/JavaSpring/NinjaGold/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.NinjaGold</groupId>

--- a/JAVA/JavaSpring/ProductsAndCategories/pom.xml
+++ b/JAVA/JavaSpring/ProductsAndCategories/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.ProductsAndCategories</groupId>

--- a/JAVA/JavaSpring/ShowTimeDate/pom.xml
+++ b/JAVA/JavaSpring/ShowTimeDate/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.stringAssignment</groupId>

--- a/JAVA/JavaSpring/StringsAssignment/pom.xml
+++ b/JAVA/JavaSpring/StringsAssignment/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.stringAssignment</groupId>

--- a/JAVA/JavaSpring/TheCode/pom.xml
+++ b/JAVA/JavaSpring/TheCode/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.TheCode</groupId>

--- a/JAVA/JavaSpring/UserController1/pom.xml
+++ b/JAVA/JavaSpring/UserController1/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.UserController1</groupId>

--- a/JAVA/JavaSpring/demo-2/pom.xml
+++ b/JAVA/JavaSpring/demo-2/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.demo</groupId>

--- a/JAVA/JavaSpring/dojoninja/pom.xml
+++ b/JAVA/JavaSpring/dojoninja/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.dojoninja</groupId>

--- a/JAVA/JavaSpring/driverslicense/pom.xml
+++ b/JAVA/JavaSpring/driverslicense/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.driverslicense</groupId>

--- a/JAVA/JavaSpring/firstproject/pom.xml
+++ b/JAVA/JavaSpring/firstproject/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.firstproject</groupId>

--- a/JAVA/JavaSpring/languages/pom.xml
+++ b/JAVA/JavaSpring/languages/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.1.RELEASE</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tomnguyen7.languages</groupId>

--- a/MEAN/Angular/Authors_Angular/package.json
+++ b/MEAN/Angular/Authors_Angular/package.json
@@ -10,9 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bcrypt": "^3.0.7",
-    "express": "^4.17.1",
-    "express-session": "^1.17.0",
-    "mongoose": "^5.7.11"
+    "bcrypt": "^5.1.1",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Angular/ProductManager/package.json
+++ b/MEAN/Angular/ProductManager/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.7.11"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Angular/RestFul_Task_Interactive/package.json
+++ b/MEAN/Angular/RestFul_Task_Interactive/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.7.10"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Angular/Restful_Task_API/package.json
+++ b/MEAN/Angular/Restful_Task_API/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Angular/Restful_Task_API_Angular/package.json
+++ b/MEAN/Angular/Restful_Task_API_Angular/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Angular/Restful_Task_Continued/package.json
+++ b/MEAN/Angular/Restful_Task_Continued/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.7.10"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Express/Counter/package.json
+++ b/MEAN/Express/Counter/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "express-session": "^1.17.0"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1"
   }
 }

--- a/MEAN/Express/Lectures/express-demo/package.json
+++ b/MEAN/Express/Lectures/express-demo/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2"
   }
 }

--- a/MEAN/Express/Lectures/express-middleware/package.json
+++ b/MEAN/Express/Lectures/express-middleware/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "express-session": "^1.17.0"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1"
   }
 }

--- a/MEAN/Express/cars_and_cats/package.json
+++ b/MEAN/Express/cars_and_cats/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2"
   }
 }

--- a/MEAN/Express/survey_form/package.json
+++ b/MEAN/Express/survey_form/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "express-session": "^1.17.0"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1"
   }
 }

--- a/MEAN/Mongoose/1955_Api/package.json
+++ b/MEAN/Mongoose/1955_Api/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.9"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Lectures/package.json
+++ b/MEAN/Mongoose/Lectures/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Message_Board/package.json
+++ b/MEAN/Mongoose/Message_Board/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Message_Board_Modular/package.json
+++ b/MEAN/Mongoose/Message_Board_Modular/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Mongoose_Dashboard/package.json
+++ b/MEAN/Mongoose/Mongoose_Dashboard/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Mongoose_Modularization/package.json
+++ b/MEAN/Mongoose/Mongoose_Modularization/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.9"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Quoting_Dojo/package.json
+++ b/MEAN/Mongoose/Quoting_Dojo/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Quoting_Dojo_Modularity/package.json
+++ b/MEAN/Mongoose/Quoting_Dojo_Modularity/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Mongoose/Restful_Task_API/package.json
+++ b/MEAN/Mongoose/Restful_Task_API/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.7.8"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Pet_Shelter/package.json
+++ b/MEAN/Pet_Shelter/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.7.11"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }

--- a/MEAN/Socket/Lectures/socket-demo/package.json
+++ b/MEAN/Socket/Lectures/socket-demo/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "socket.io": "^2.3.0"
+    "express": "^4.21.2",
+    "socket.io": "^4.8.1"
   }
 }

--- a/MEAN/Socket/button_game/package.json
+++ b/MEAN/Socket/button_game/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "socket.io": "^2.3.0"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "socket.io": "^4.8.1"
   }
 }

--- a/MEAN/Socket/examples/package.json
+++ b/MEAN/Socket/examples/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "socket.io": "^2.3.0"
+    "express": "^4.21.2",
+    "socket.io": "^4.8.1"
   }
 }

--- a/MEAN/Socket/group_chat/package.json
+++ b/MEAN/Socket/group_chat/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "socket.io": "^2.3.0"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "socket.io": "^4.8.1"
   }
 }

--- a/MEAN/Socket/real_time_colors/package.json
+++ b/MEAN/Socket/real_time_colors/package.json
@@ -10,8 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "socket.io": "^2.3.0"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "socket.io": "^4.8.1"
   }
 }

--- a/MEAN/Socket/survey_form_revisited/package.json
+++ b/MEAN/Socket/survey_form_revisited/package.json
@@ -10,9 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ejs": "^2.7.1",
-    "express": "^4.17.1",
-    "express-session": "^1.17.0",
-    "socket.io": "^2.3.0"
+    "ejs": "^3.1.10",
+    "express": "^4.21.2",
+    "express-session": "^1.18.1",
+    "socket.io": "^4.8.1"
   }
 }

--- a/React/ReactBasics/data-fetching/package.json
+++ b/React/ReactBasics/data-fetching/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "axios": "^0.19.1",
+    "axios": "^1.7.9",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-scripts": "3.3.0"

--- a/React/lecture/express-demo/package.json
+++ b/React/lecture/express-demo/package.json
@@ -10,6 +10,6 @@
   "author": "Tom Nguuyen",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "^4.21.2"
   }
 }

--- a/React/lecture/mongoose-demo/package.json
+++ b/React/lecture/mongoose-demo/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1",
-    "mongoose": "^5.8.7"
+    "express": "^4.21.2",
+    "mongoose": "^8.9.5"
   }
 }


### PR DESCRIPTION
Updates vulnerable dependency versions to clear Dependabot advisories (direct pushes to `master` return 403 in this environment, so this goes via PR).

- **Maven (23 `pom.xml`):** bump `spring-boot-starter-parent` 2.0.x/2.2.x → **2.7.18** (last Java-8-compatible line), updating the managed dependency tree to patched releases.
- **npm (30 `package.json`):** bump server-side deps that have no safe in-range version — `mongoose` ^5 → ^8.9.5, `ejs` ^2 → ^3.1.10, `socket.io` ^2 → ^4.8.1, `axios` 0.19 → ^1.7.9, `bcrypt` ^3 → ^5.1.1, and raise `express`/`express-session` floors to patched versions.

Source code is unchanged. The remaining advisories are concentrated in the Angular 8 / Gatsby 2 / react-scripts 3 frontend trees, which have no in-place patched version (they'd require breaking major-framework migrations).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATaS4h84zqAej4eCxkgcP6)_