### PR TITLE
Override Spring Boot managed dependency versions to patched releases

### DIFF
--- a/JAVA/JavaSpring/CompanyFounders/bin/pom.xml
+++ b/JAVA/JavaSpring/CompanyFounders/bin/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/CompanyFounders/pom.xml
+++ b/JAVA/JavaSpring/CompanyFounders/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/Counter/pom.xml
+++ b/JAVA/JavaSpring/Counter/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/Course/pom.xml
+++ b/JAVA/JavaSpring/Course/pom.xml
@@ -18,7 +18,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-    </properties>
+    		<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
+	</properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/JAVA/JavaSpring/DojoOverflow/pom.xml
+++ b/JAVA/JavaSpring/DojoOverflow/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/DojoSurvey/pom.xml
+++ b/JAVA/JavaSpring/DojoSurvey/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/EventBeltReviewer/pom.xml
+++ b/JAVA/JavaSpring/EventBeltReviewer/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/FamiliarWithRouting/pom.xml
+++ b/JAVA/JavaSpring/FamiliarWithRouting/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/GreatIdeas/pom.xml
+++ b/JAVA/JavaSpring/GreatIdeas/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/HelloHuman/pom.xml
+++ b/JAVA/JavaSpring/HelloHuman/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/MVC/pom.xml
+++ b/JAVA/JavaSpring/MVC/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/Movies/pom.xml
+++ b/JAVA/JavaSpring/Movies/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/NinjaGold/pom.xml
+++ b/JAVA/JavaSpring/NinjaGold/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/ProductsAndCategories/pom.xml
+++ b/JAVA/JavaSpring/ProductsAndCategories/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/ShowTimeDate/pom.xml
+++ b/JAVA/JavaSpring/ShowTimeDate/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/StringsAssignment/pom.xml
+++ b/JAVA/JavaSpring/StringsAssignment/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/TheCode/pom.xml
+++ b/JAVA/JavaSpring/TheCode/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/UserController1/pom.xml
+++ b/JAVA/JavaSpring/UserController1/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/demo-2/pom.xml
+++ b/JAVA/JavaSpring/demo-2/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/dojoninja/pom.xml
+++ b/JAVA/JavaSpring/dojoninja/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/driverslicense/pom.xml
+++ b/JAVA/JavaSpring/driverslicense/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/firstproject/pom.xml
+++ b/JAVA/JavaSpring/firstproject/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>

--- a/JAVA/JavaSpring/languages/pom.xml
+++ b/JAVA/JavaSpring/languages/pom.xml
@@ -17,6 +17,10 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+			<spring-framework.version>5.3.39</spring-framework.version>
+		<tomcat.version>9.0.106</tomcat.version>
+		<snakeyaml.version>2.2</snakeyaml.version>
+		<logback.version>1.2.13</logback.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Pins `spring-framework` 5.3.39, `tomcat` 9.0.106, `snakeyaml` 2.2, and `logback` 1.2.13 via `pom.xml` properties across all 23 Maven projects — the latest patched releases within the Java-8-compatible lines. Clears the residual Spring/Tomcat/snakeyaml/logback advisories without the breaking Spring Boot 3 (Java 17) upgrade.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATaS4h84zqAej4eCxkgcP6)_